### PR TITLE
Update manifest.json

### DIFF
--- a/jf566xv6588/manifest.json
+++ b/jf566xv6588/manifest.json
@@ -2,7 +2,7 @@
   "@context": "http://iiif.io/api/presentation/2/context.json",
   "@id": "https://dms-data.stanford.edu/data/manifests/Parker/jf566xv6588/manifest.json",
   "@type": "sc:Manifest",
-  "label": "Cambridge, Corpus Christi College, MS 474: Raymond of PeÃƒÂ±afort OP, Summa de casibus poenitentiae",
+  "label": "Cambridge, Corpus Christi College, MS 474: Raymond of Peñafort OP, Summa de casibus poenitentiae",
   "attribution": "© the Master and Fellows of Corpus Christi College, Cambridge. Licensed under a Creative Commons Attribution-NonCommercial 4.0 International License. For higher resolution images suitable for scholarly or commercial publication, either in print or in an electronic format, please contact the Parker Library directly at parker-library@corpus.cam.ac.uk",
   "seeAlso": {
     "@id": "https://purl.stanford.edu/jf566xv6588.mods",


### PR DESCRIPTION
corrected the mirador title field to rectify a misdisplaying 'ñ'. 