### PR TITLE
Update 2r.json

### DIFF
--- a/nm203xw8381/list/2r.json
+++ b/nm203xw8381/list/2r.json
@@ -12,7 +12,7 @@
         "@id": "https://dms-data.stanford.edu/data/manifests/Parker/nm203xw8381/res/2ee7b226-1f0f-4862-8591-e340e4ff3219",
         "@type": "cnt:ContentAsText",
         "format": "text/plain",
-        "chars": "Col. 1 is in coloured capitals"
+        "chars": "Col. 1 is in coloured capitals: red, blue, green, yellow, and contains 13 lines of 8-10 letters each"
       }
     }
   ]


### PR DESCRIPTION
added the missing text. Is it possible that it stopped scripting after a 'comma'? text:  red, blue, green, yellow, and contains 13 lines of 8-10 letters each'