### PR TITLE
Update manifest.json

### DIFF
--- a/bm891ts1074/manifest.json
+++ b/bm891ts1074/manifest.json
@@ -12851,7 +12851,7 @@
         {
           "@id": "https://dms-data.stanford.edu/data/manifests/Parker/bm891ts1074/canvas/canvas-475",
           "@type": "sc:Canvas",
-          "label": "p. 459_487_SPRD",
+          "label": "p. 460_487_SPRD",
           "height": 6874,
           "width": 9198,
           "images": [


### PR DESCRIPTION
updated label on line 12845 to reflect the actual pages displayed in the spread (despite image name -- which is fair enough, it's a recto-verso issue with the pages.