### PR TITLE
Update 47.json

### DIFF
--- a/kt259wr5908/list/47.json
+++ b/kt259wr5908/list/47.json
@@ -7,7 +7,7 @@
       "@id": "https://dms-data.stanford.edu/data/manifests/Parker/kt259wr5908/annotation/1fbf2557-c359-4b48-b6be-7ee988711f19",
       "@type": "oa:Annotation",
       "motivation": "oa:commenting",
-      "on": "https://dms-data.stanford.edu/data/manifests/Parker/kt259wr5908/canvas/canvas-55a#xywh=0,0,1788,4902",
+      "on": "https://dms-data.stanford.edu/data/manifests/Parker/kt259wr5908/canvas/canvas-55a#xywh=0,0,6185,8928",
       "resource": {
         "@id": "https://dms-data.stanford.edu/data/manifests/Parker/kt259wr5908/res/9756bac8-280b-4229-8aee-c12e95856ebe",
         "@type": "cnt:ContentAsText",


### PR DESCRIPTION
re-locusing the annotation so that it covers its new canvas (was on tiny p. 47a before, now it needed to fit full sized p. 47)